### PR TITLE
Fix typo in path for make_amended_view.sql

### DIFF
--- a/run_sql.sh
+++ b/run_sql.sh
@@ -1,3 +1,3 @@
 psql -U postgres politics -f ./sql_scripts/create_tables.sql
 psql -U postgres politics -f ./sql_scripts/import_data.sql
-psql -U postgres politics -f ./sql_scripts/make_ammend_view.sql
+psql -U postgres politics -f ./sql_scripts/make_amended_view.sql


### PR DESCRIPTION
Noticed that this (presumed?) typo in the path breaks the script—works when changed to `make_amended_view.sql`, matching the file in `sql_scripts`.